### PR TITLE
build/gcw/glutexto.sh: Absolute LD_LIBRARY_PATH

### DIFF
--- a/build/gcw/glutexto.sh
+++ b/build/gcw/glutexto.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd glutexto
-LD_LIBRARY_PATH=. ./glutexto
+LD_LIBRARY_PATH="$(pwd)" ./glutexto


### PR DESCRIPTION
Relative path doesn't seem to work with the latest OpenDingux/gmenu2x
I'm not sure why that is, but this fixes it for the time being